### PR TITLE
chore: add appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,20 @@
+skip_tags: true
+clone_folder: c:\projects\metmask
+image: Visual Studio 2017
+build: off
+
+environment:
+  matrix:
+    - PYTHON: "C:\\Miniconda"
+    - PYTHON: "C:\\Miniconda-x64"
+    - PYTHON: "C:\\Miniconda36"
+    - PYTHON: "C:\\Miniconda36-x64"
+
+install:
+  - cd c:\projects\metmask
+  - dir
+  - "%PYTHON%/Scripts/conda.exe install -y pytest future six"
+  - "%PYTHON%/Scripts/pip.exe install ."
+
+test_script:
+  - "%PYTHON%/Scripts/py.test.exe -v -rsx"


### PR DESCRIPTION
The Appveyor build failed like this https://ci.appveyor.com/project/kozo2/metmask/build/job/w2ao1ohmo27mi503
, but I send this pull request at this point.